### PR TITLE
Feature/transmit string

### DIFF
--- a/src/CanSatKitRadio.cpp
+++ b/src/CanSatKitRadio.cpp
@@ -466,6 +466,10 @@ bool Radio::transmit(const char* str) {
   return transmit(str, strlen(str));
 }
 
+bool Radio::transmit(String str) {
+  return transmit(str.c_str(), strlen(str.c_str()));
+}
+
 bool Radio::transmit(const char* data, std::uint8_t length) {
   return transmit((const uint8_t *)(data), length);
 }

--- a/src/CanSatKitRadio.cpp
+++ b/src/CanSatKitRadio.cpp
@@ -472,6 +472,10 @@ bool Radio::transmit(const char* str) {
   return transmit(reinterpret_cast<const uint8_t*>(str), length + 1);
 }
 
+bool Radio::transmit(String str) {
+  return transmit(str.c_str());
+}
+
 bool Radio::transmit(const uint8_t* data, uint8_t length) {
   if (length == 0) {
     if (debug_enabled) {

--- a/src/CanSatKitRadio.h
+++ b/src/CanSatKitRadio.h
@@ -69,6 +69,7 @@ class Radio {
   static void disable_debug();
   
   static bool transmit(Frame frame);
+  static bool transmit(String str);
   static bool transmit(const char* str);
   static bool transmit(const char* data, std::uint8_t length);
   static bool transmit(const std::uint8_t* data, std::uint8_t length);


### PR DESCRIPTION
This PR provides simple utility function for calling `radio.transmit` method with `String` parameter.
This will probably save a-lot-of-time for beginners - since [`TransmitSimple`](https://github.com/CanSatKit/CanSatKitLibrary/blob/master/examples/TransmitSimple/TransmitSimple.ino#L19) example would suggest it might get `String` passed.

If anything else if needed before merge, I'm more than happy to help!